### PR TITLE
Fixes for A and MX without domain-spec

### DIFF
--- a/lib/uspf.ml
+++ b/lib/uspf.ml
@@ -525,15 +525,15 @@ let pp_dual_cidr ppf = function
 
 let pp_mechanism ppf = function
   | A (v, cidr_v4, cidr_v6) ->
-      Fmt.pf ppf "a:%a%a"
-        Fmt.(option Domain_name.pp)
+      Fmt.pf ppf "a%a%a"
+        Fmt.(option (any ":" ++  Domain_name.pp))
         v pp_dual_cidr (cidr_v4, cidr_v6)
   | All -> Fmt.string ppf "all"
   | Exists v -> Fmt.pf ppf "exists:%a" Domain_name.pp v
   | Include v -> Fmt.pf ppf "include:%a" Domain_name.pp v
   | Mx (v, cidr_v4, cidr_v6) ->
-      Fmt.pf ppf "mx:%a%a"
-        Fmt.(option Domain_name.pp)
+      Fmt.pf ppf "mx%a%a"
+        Fmt.(option (any ":" ++ Domain_name.pp))
         v pp_dual_cidr (cidr_v4, cidr_v6)
   | Ptr (Some v) -> Fmt.pf ppf "ptr:%a" Domain_name.pp v
   | Ptr None -> ()

--- a/lib/uspf.ml
+++ b/lib/uspf.ml
@@ -971,9 +971,25 @@ and apply :
       a_mechanism ~ctx ~limit state dns
         (module DNS)
         q domain_name (cidr_ipv4, cidr_ipv6)
+  | A (None, cidr_ipv4, cidr_ipv6) ->
+      let domain_name = Map.get Map.K.domain ctx in
+      Log.debug (fun m ->
+          m "Apply A mechanism with no domain, using %a."
+            Domain_name.pp domain_name) ;
+      a_mechanism ~ctx ~limit state dns
+        (module DNS)
+        q domain_name (cidr_ipv4, cidr_ipv6)
   | Mx (Some domain_name, cidr_ipv4, cidr_ipv6) ->
       Log.debug (fun m ->
           m "Apply MX mechanism with %a." Domain_name.pp domain_name) ;
+      mx_mechanism ~ctx ~limit state dns
+        (module DNS)
+        q domain_name (cidr_ipv4, cidr_ipv6)
+  | Mx (None, cidr_ipv4, cidr_ipv6) ->
+      let domain_name = Map.get Map.K.domain ctx in
+      Log.debug (fun m ->
+          m "Apply MX mechanism with no domain, using %a."
+            Domain_name.pp domain_name) ;
       mx_mechanism ~ctx ~limit state dns
         (module DNS)
         q domain_name (cidr_ipv4, cidr_ipv6)
@@ -993,7 +1009,6 @@ and apply :
       return
         (of_qualifier ~mechanism q
            (Ipaddr.Prefix.mem (Map.get Map.K.ip ctx) (Ipaddr.V6 v6)))
-  | A (None, _, _) | Mx (None, _, _) -> return `Continue
   | Exists domain_name ->
       exists_mechanism ~ctx ~limit state dns (module DNS) q domain_name
   | Ptr _ -> return `Continue

--- a/test/test_macro.ml
+++ b/test/test_macro.ml
@@ -1,6 +1,7 @@
 open Rresult
 
 let msg = Alcotest.testable Rresult.R.pp_msg ( = )
+let ( <.> ) f g = fun x -> f (g x)
 
 let test01 =
   Alcotest.test_case "rfc7208" `Quick @@ fun () ->
@@ -129,6 +130,48 @@ let test04 =
   let str = Uspf.record_to_string record in
   Alcotest.(check string) "record" str "ip4:192.168.0.0/24 ip4:10.0.0.0/24 -all"
 
+let test05 =
+  Alcotest.test_case "mx optional domain name" `Quick @@ fun () ->
+  let module Caml = Uspf.Sigs.Make (struct type 'a t = 'a end) in
+  let state =
+    { Uspf.Sigs.bind= (fun x f -> f (Caml.prj x))
+    ; Uspf.Sigs.return= Caml.inj } in
+  let module DNS = struct
+    type backend = Caml.t
+    type t = unit
+
+    type error =
+      [ `Msg of string
+      | `No_data of [ `raw ] Domain_name.t * Dns.Soa.t
+      | `No_domain of [ `raw ] Domain_name.t * Dns.Soa.t ]
+
+    let getrrecord
+      : type a. t -> a Dns.Rr_map.rr -> _ Domain_name.t -> ((a, [> error ]) result, backend) Uspf.Sigs.io
+      = fun () rr domain_name ->
+      let _192_168_1_1 = Ipaddr.V4.(Set.singleton (of_string_exn "192.168.1.1")) in
+      let mxs = Dns.Rr_map.Mx_set.singleton
+        { Dns.Mx.preference= 10
+        ; mail_exchange= Domain_name.(host_exn (of_string_exn "mail.bar.com")) } in
+      Fmt.pr ">>> Ask for %a:%a.\n%!"
+        Dns.Rr_map.ppk (Dns.Rr_map.K rr)
+        Domain_name.pp domain_name;
+      match rr, Domain_name.to_string domain_name with
+      | Dns.Rr_map.Txt, "bar.com" -> Caml.inj (Ok (0l, Dns.Rr_map.Txt_set.singleton "v=spf1 mx a:foo.com -all"))
+      | Dns.Rr_map.A, "mail.bar.com" -> Caml.inj (Ok (0l, _192_168_1_1))
+      | Dns.Rr_map.Mx, "bar.com" -> Caml.inj (Ok (0l, mxs))
+      | _ -> Caml.inj (R.error_msgf "Error on %a:%a." Dns.Rr_map.ppk (Dns.Rr_map.K rr) Domain_name.pp domain_name)
+  end in
+  let ctx =
+    Uspf.empty
+    |> Uspf.with_sender (`HELO (Domain_name.of_string_exn "bar.com"))
+    |> Uspf.with_sender (`MAILFROM (Colombe.Path.of_string_exn "<x@bar.com>"))
+    |> Uspf.with_ip (Ipaddr.of_string_exn "192.168.1.1") in
+  match Uspf.get ~ctx state () (module DNS) |> Caml.prj
+        >>| (Caml.prj <.> Uspf.check ~ctx state () (module DNS)) with
+  | Ok (`Pass _) -> Alcotest.(check pass) "spf" () ()
+  | Ok res -> Alcotest.failf "Invalid SPF result: %a." Uspf.pp_res res
+  | Error (`Msg err) -> Alcotest.failf "%s." err
+
 let () =
   Alcotest.run "decoding"
-    [ ("macro", [ test01; test02 ]); ("record", [ test03; test04 ]) ]
+    [ ("macro", [ test01; test02 ]); ("record", [ test03; test04 ]); ("spf", [ test05 ]) ]


### PR DESCRIPTION
Hey,

not sure how test cases are best done, but for my domain (mehnert.org), when my mail server sends a mail, uspf reports failure.

The SPF record is "mx a:mail.h3q.com -all", and uspf bails at "mx" without a domain-spec.

These commits fix the behaviour. For testing with bin/example.ml, I use the following patch:
```diff
--- a/bin/example.ml
+++ b/bin/example.ml
@@ -9,9 +9,9 @@ let receiver =
 
 let ctx0 =
   Uspf.empty
-  |> Uspf.with_sender (`HELO github_com)
-  |> Uspf.with_sender (`MAILFROM noreply_github_com)
-  |> Uspf.with_ip (Ipaddr.of_string_exn "192.30.252.192")
+  |> Uspf.with_sender (`HELO (Domain_name.of_string_exn "mehnert.org"))
+  |> Uspf.with_sender (`MAILFROM (Colombe.Path.of_string_exn "<hannes@mehnert.org>"))
+  |> Uspf.with_ip (Ipaddr.of_string_exn "213.73.89.200")
 
 let ctx1 =
   Uspf.empty
```